### PR TITLE
Fix path to find clangd executable

### DIFF
--- a/lua/installer/builtins/ls/clangd.lua
+++ b/lua/installer/builtins/ls/clangd.lua
@@ -42,9 +42,9 @@ return {
     local module_path = require("installer/utils/fs").module_path
 
     if require("installer/utils/os").is_windows then
-      config.default_config.cmd[1] = module_path(clang) .. "./clangd/bin/clangd.exe"
+      config.default_config.cmd[1] = module_path("ls","clangd") .. "./clangd/bin/clangd.exe"
     else
-      config.default_config.cmd[1] = module_path(clang) .. "./clangd/bin/clangd"
+      config.default_config.cmd[1] = module_path("ls","clangd") .. "./clangd/bin/clangd"
     end
 
     return config


### PR DESCRIPTION
Fixes clangd.exe not being found in windows.